### PR TITLE
Add mono-locale-extras to RHEL installed packages

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -22,3 +22,8 @@
 
   - name: Ensure mediainfo is installed
     package: name=mediainfo state=present
+  
+  - name: Ensure mono locale extras is installed
+    yum:
+      name: mono-locale-extras
+      state: present 


### PR DESCRIPTION
Addresses #1 . Mono is unable to correctly parse directories. 